### PR TITLE
chore: autoplay description on muted

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -183,6 +183,7 @@ function App() {
             controls: true,
             playsinline: true,
             rel: false,
+            muted: true,
           }}
           onReady={handleReady}
           onStateChange={handleStateChange}

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -3,6 +3,9 @@ import type { DimensionValue, StyleProp, ViewStyle } from 'react-native';
 import type { WebViewProps } from 'react-native-webview';
 
 export type YoutubePlayerVars = {
+  /**
+   * @description If the `muted` is not set to true when activating the `autoplay`, it may not work properly depending on browser policy. (https://developer.chrome.com/blog/autoplay)
+   */
   autoplay?: boolean;
   controls?: boolean;
   loop?: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - YouTube videos now start muted by default when played in the app.

- **Documentation**
  - Added clarification about browser autoplay policies for YouTube videos to developer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->