### PR TITLE
fix: change props name from webviewProps to webViewProps

### DIFF
--- a/.changeset/clean-banks-rescue.md
+++ b/.changeset/clean-banks-rescue.md
@@ -1,0 +1,6 @@
+---
+"react-native-youtube-bridge": minor
+---
+
+fix: change props name from webviewProps to webViewProps
+

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -189,11 +189,11 @@ function App() {
         aspectRatio: 16 / 9,
       }}
       // iOS, Android 플랫폼 지원
-      webviewStyle={{
+      webViewStyle={{
         // ...
       }}
       // iOS, Android 플랫폼 지원
-      webviewProps={{
+      webViewProps={{
         // ...
       }}
     />

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ function App() {
         aspectRatio: 16 / 9,
       }}
       // iOS, Android platform support
-      webviewStyle={{
+      webViewStyle={{
         // ...
       }}
       // iOS, Android platform support
-      webviewProps={{
+      webViewProps={{
         // ...
       }}
     />

--- a/src/YoutubePlayer.tsx
+++ b/src/YoutubePlayer.tsx
@@ -34,7 +34,7 @@ const YoutubePlayer = forwardRef<PlayerControls, YoutubePlayerProps>(
         rel: false,
       },
       webViewStyle,
-      webviewProps,
+      webViewProps,
     },
     ref,
   ) => {
@@ -243,7 +243,7 @@ const YoutubePlayer = forwardRef<PlayerControls, YoutubePlayerProps>(
           source={{ html: createPlayerHTML() }}
           style={[styles.webView, webViewStyle]}
           onMessage={handleMessage}
-          {...webviewProps}
+          {...webViewProps}
           javaScriptEnabled
           domStorageEnabled
           allowsFullscreenVideo

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -36,7 +36,7 @@ export type YoutubePlayerProps = {
   /**
    * @platform ios, android
    */
-  webviewProps?: Omit<WebViewProps, 'ref' | 'source' | 'style' | 'onMessage'>;
+  webViewProps?: Omit<WebViewProps, 'ref' | 'source' | 'style' | 'onMessage'>;
   /**
    * @platform web
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the casing of prop names from `webviewProps` to `webViewProps` and `webviewStyle` to `webViewStyle` in the `YoutubePlayer` component and documentation for consistency.

- **Documentation**
  - Updated example usage in the README files to reflect the corrected prop names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->