### PR TITLE
chore(package.json): remove src folder when uploading to npm (-53.5kb)

### DIFF
--- a/.changeset/olive-boxes-cheat.md
+++ b/.changeset/olive-boxes-cheat.md
@@ -1,0 +1,5 @@
+---
+"react-native-youtube-bridge": patch
+---
+
+chore(package.json): remove src folder when uploading to npm (-53.5kb)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "src",
     "lib",
     "android",
     "ios",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the package size by excluding the "src" folder from the npm package upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->