### PR TITLE
fix: override webview source props (header, method, body)

### DIFF
--- a/.changeset/clear-pigs-stop.md
+++ b/.changeset/clear-pigs-stop.md
@@ -1,0 +1,5 @@
+---
+"react-native-youtube-bridge": patch
+---
+
+fix: override webview source props (method, body, header)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -182,6 +182,9 @@ function App() {
             rel: false,
             muted: true,
           }}
+          webViewProps={{
+            renderToHardwareTextureAndroid: true,
+          }}
           progressInterval={progressInterval}
           onReady={handleReady}
           onStateChange={handleStateChange}

--- a/src/YoutubePlayer.tsx
+++ b/src/YoutubePlayer.tsx
@@ -268,7 +268,11 @@ const YoutubePlayer = forwardRef<PlayerControls, YoutubePlayerProps>(
           {...webViewProps}
           ref={webViewRef}
           javaScriptEnabled
-          source={useInlineHtml ? { html: createPlayerHTML(), baseUrl: webViewBaseUrl } : { uri: webViewUrl }}
+          source={
+            useInlineHtml
+              ? { html: createPlayerHTML(), baseUrl: webViewBaseUrl }
+              : { ...(webViewProps?.source ?? {}), uri: webViewUrl }
+          }
           onMessage={handleMessage}
           onError={(error) => {
             console.error('WebView error:', error);

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react';
 import type { DimensionValue, StyleProp, ViewStyle } from 'react-native';
 import type { WebViewProps } from 'react-native-webview';
+import type { WebViewSourceUri } from 'react-native-webview/lib/WebViewTypes';
 
 export type YoutubePlayerVars = {
   /**
@@ -84,7 +85,9 @@ export type YoutubePlayerProps = {
   /**
    * @platform ios, android
    */
-  webViewProps?: Omit<WebViewProps, 'ref' | 'source' | 'style' | 'onMessage' | 'javaScriptEnabled' | 'onError'>;
+  webViewProps?: Omit<WebViewProps, 'ref' | 'source' | 'style' | 'onMessage' | 'javaScriptEnabled' | 'onError'> & {
+    source?: Omit<WebViewSourceUri, 'uri'>;
+  };
   /**
    * @platform web
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for passing additional WebView source properties (such as HTTP method, request body, and headers) to the YoutubePlayer component.
  - Introduced the ability to configure Android hardware texture rendering for the player.

- **Bug Fixes**
  - Fixed the behavior of overriding WebView source properties to ensure custom HTTP method, body, and headers are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->