### PR TITLE
fix: remove private flag to enable npm publishing

### DIFF
--- a/.changeset/calm-dolls-cheat.md
+++ b/.changeset/calm-dolls-cheat.md
@@ -1,0 +1,6 @@
+---
+"@react-native-youtube-bridge/react": patch
+"@react-native-youtube-bridge/core": patch
+---
+
+fix: remove private flag to enable npm publishing

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,6 @@
   "name": "@react-native-youtube-bridge/core",
   "version": "1.0.0",
   "description": "Core package for react-native-youtube-bridge",
-  "private": true,
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,6 @@
   "name": "@react-native-youtube-bridge/react",
   "version": "1.0.0",
   "description": "React implementation for react-native-youtube-bridge",
-  "private": true,
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Removed "private": true from package.json
- Packages are now ready for npm publication