### PR TITLE
fix(types): preserve TSDoc in YoutubePlayer component props

### DIFF
--- a/.changeset/vast-bats-clap.md
+++ b/.changeset/vast-bats-clap.md
@@ -1,0 +1,10 @@
+---
+"react-native-youtube-bridge": patch
+---
+
+fix(types): preserve TSDoc in YoutubePlayer component props
+
+- Add explicit type annotation to maintain interface reference
+- Fix Go to Definition to navigate to YoutubePlayerProps interface
+- Ensure IntelliSense displays JSDoc comments for component props
+- Prevent TypeScript compiler from inlining props type definition

--- a/packages/react-native-youtube-bridge/src/index.tsx
+++ b/packages/react-native-youtube-bridge/src/index.tsx
@@ -1,5 +1,7 @@
-export { default as YoutubePlayer } from './YoutubePlayer';
-export type { YoutubePlayerProps } from './types/youtube';
+import type { PlayerControls } from '@react-native-youtube-bridge/core';
+import type { YoutubePlayerProps } from './types/youtube';
+import YoutubePlayerComponent from './YoutubePlayer';
+
 export {
   ERROR_CODES,
   PlayerState,
@@ -12,3 +14,8 @@ export {
   type PlayerControls,
 } from '@react-native-youtube-bridge/core';
 export { useYoutubeOEmbed } from '@react-native-youtube-bridge/react';
+
+export const YoutubePlayer: React.ForwardRefExoticComponent<YoutubePlayerProps & React.RefAttributes<PlayerControls>> =
+  YoutubePlayerComponent;
+
+export type { YoutubePlayerProps };


### PR DESCRIPTION
- Add explicit type annotation to maintain interface reference
- Fix Go to Definition to navigate to YoutubePlayerProps interface
- Ensure IntelliSense displays JSDoc comments for component props
- Prevent TypeScript compiler from inlining props type definition