### PR TITLE
fix: align inline baseUrl with IFrame origin

### DIFF
--- a/.changeset/fresh-drinks-slide.md
+++ b/.changeset/fresh-drinks-slide.md
@@ -1,0 +1,9 @@
+---
+"react-native-youtube-bridge": patch
+---
+
+fix: align inline baseUrl with IFrame origin
+
+- add trailing-slash handling for WebView baseUrl in inline mode
+- propagate origin/playerVars into local HTML
+- refine YoutubeView WebView source resolution

--- a/.changeset/slow-kings-lay.md
+++ b/.changeset/slow-kings-lay.md
@@ -1,0 +1,5 @@
+---
+"react-native-youtube-bridge": patch
+---
+
+docs: update TSDoc for webViewUrl/inline behavior

--- a/packages/react-native-youtube-bridge/src/YoutubeView.tsx
+++ b/packages/react-native-youtube-bridge/src/YoutubeView.tsx
@@ -40,9 +40,12 @@ function YoutubeView({
   // biome-ignore lint/correctness/useExhaustiveDependencies: webViewProps.source is intentionally excluded to prevent unnecessary re-renders
   const webViewSource = useMemo(() => {
     if (useInlineHtml) {
+      const webViewBaseUrlWithSlash =
+        webViewBaseUrl && (webViewBaseUrl.endsWith('/') ? webViewBaseUrl : `${webViewBaseUrl}/`);
+
       return {
         html: createPlayerHTML(),
-        baseUrl: webViewBaseUrl ?? 'https://localhost/',
+        baseUrl: webViewBaseUrlWithSlash || 'https://localhost/',
       };
     }
 
@@ -111,7 +114,7 @@ function YoutubeView({
         }
       } catch (error) {
         if (__DEV__) {
-          console.error('Error parsing WebView message:', error);
+          console.error('Error parsing WebView message:', error, event?.nativeEvent?.data);
         }
         player.emit('error', { code: 1000, message: 'FAILED_TO_PARSE_WEBVIEW_MESSAGE' });
       }

--- a/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
@@ -25,7 +25,7 @@ const useCreateLocalPlayerHtml = ({
       return '<html><body><div style="width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; color: #fff;">Invalid YouTube ID</div></body></html>';
     }
 
-    const safeOrigin = escapeHtml(origin) ?? 'https://localhost';
+    const safeOrigin = escapeHtml(origin) || 'https://localhost';
     const safeStartTime = safeNumber(startTime);
     const safeEndTime = endTime ? safeNumber(endTime) : undefined;
 

--- a/packages/react-native-youtube-bridge/src/types/youtube.ts
+++ b/packages/react-native-youtube-bridge/src/types/youtube.ts
@@ -54,8 +54,9 @@ export type YoutubeViewProps = {
    * The URL for the WebView source.
    * @remark
    * When `useInlineHtml` is `true`, this value is set as the `baseUrl` for HTML content.
-   * In this case, the origin of `webViewUrl` MUST match the YouTube IFrame API `origin`
-   * (e.g. baseUrl `https://localhost/` ⇄ origin `https://localhost`).
+   * In this case, the origin of `webViewUrl` MUST exactly match the YouTube IFrame API `origin`.
+   * - Include the port when applicable (e.g. baseUrl `https://localhost:8081/` ⇄ origin `https://localhost:8081`).
+   * - Use a trailing slash on the `baseUrl`, but not on `origin` (scheme + host [+ port] only).
    *
    * When `useInlineHtml` is `false`, this value overrides the default URI for the WebView source (https://react-native-youtube-bridge.pages.dev).
    * @platform ios, android


### PR DESCRIPTION
- add trailing-slash handling for WebView baseUrl in inline mode
- propagate origin/playerVars into local HTML
- refine YoutubeView WebView source resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Normalize inline WebView base URL with trailing slash and safe default.
  - Align inline baseUrl with IFrame origin; propagate origin and playerVars into local HTML.
  - Refine WebView source resolution.
  - Improve error logging for WebView messages.

- Documentation
  - Clarify webViewUrl/inline behavior: exact origin match, include port when applicable, use trailing slash on baseUrl.

- Chores
  - Add patch release entries for react-native-youtube-bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->