### PR TITLE
chore(docs): replace @remark with @remarks per TSDoc spec

### DIFF
--- a/.changeset/funny-baths-carry.md
+++ b/.changeset/funny-baths-carry.md
@@ -1,0 +1,11 @@
+---
+"react-native-youtube-bridge": patch
+"@react-native-youtube-bridge/core": patch
+---
+
+chore(docs): replace @remark with @remarks per TSDoc spec
+
+- TSDoc specifies the tag name as `@remarks` (not `@remark`).
+- This aligns our comments with the spec and improves tooling support.
+- No runtime behavior changes.
+- Ref: https://tsdoc.org/pages/tags/remarks/

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -119,14 +119,14 @@ export type PlayerEvents = {
 export type YoutubePlayerVars = {
   /**
    * This parameter specifies whether the initial video will automatically start to play when the player loads.
-   * @remark
+   * @remarks
    * - If the `muted` is not set to true when activating the `autoplay`,
    * - it may not work properly depending on browser policy. (https://developer.chrome.com/blog/autoplay)
    */
   autoplay?: boolean;
   /**
    * This parameter indicates whether the video player controls are displayed.
-   * @remark
+   * @remarks
    * - `controls: false` - Player controls do not display in the player.
    * - `controls: true` (default) - Player controls display in the player.
    * @defaultValue true
@@ -152,7 +152,7 @@ export type YoutubePlayerVars = {
   /**
    * This parameter controls whether videos play inline or fullscreen on iOS.
    *
-   * @remark
+   * @remarks
    * Valid values are:
    * - `playsinline: false` - Results in fullscreen playback. This is currently the default value, though the default is subject to change.
    * - `playsinline: true` - Results in inline playback for mobile browsers and for WebViews created with the `allowsInlineMediaPlayback` property set to `YES`.
@@ -160,14 +160,14 @@ export type YoutubePlayerVars = {
   playsinline?: boolean;
   /**
    * Prior to the change, this parameter indicates whether the player should show related videos when playback of the initial video ends.
-   * @remark
+   * @remarks
    * After the change, you will not be able to disable related videos. Instead, if the `rel` parameter is set to `false, related videos will come from the same channel as the video that was just played.
    */
   rel?: boolean;
   /**
    * This parameter provides an extra security measure for the IFrame API and is only supported for IFrame embeds.
    *
-   * @remark
+   * @remarks
    * - When `useInlineHtml` is `true` (iOS/Android inline WebView), if not provided, the library defaults this to `https://localhost` and sets the WebView `baseUrl` accordingly so that the document origin and this value match.
    * - When `useInlineHtml` is `false` (remote WebView), if not provided, the external page URL defaults to `https://react-native-youtube-bridge.pages.dev` and this value follows that URL. If you pass a custom `webViewUrl` (base URL), `origin` should follow that same origin.
    * - In all cases, this value MUST exactly match the document's origin that hosts the iframe for the YouTube IFrame API to function correctly.

--- a/packages/react-native-youtube-bridge/src/types/youtube.ts
+++ b/packages/react-native-youtube-bridge/src/types/youtube.ts
@@ -43,7 +43,7 @@ export type YoutubeViewProps = {
   iframeStyle?: CSSProperties;
   /**
    * If set to true, the player will use inline HTML.
-   * @remark
+   * @remarks
    * When false, the player will use a webview with the default URI (https://react-native-youtube-bridge.pages.dev).
    * To use a custom webview, set `webViewUrl` to your own URL.
    * @defaultValue true
@@ -52,7 +52,7 @@ export type YoutubeViewProps = {
   useInlineHtml?: boolean;
   /**
    * The URL for the WebView source.
-   * @remark
+   * @remarks
    * When `useInlineHtml` is `true`, this value is set as the `baseUrl` for HTML content.
    * In this case, the origin of `webViewUrl` MUST exactly match the YouTube IFrame API `origin`.
    * - Include the port when applicable (e.g. baseUrl `https://localhost:8081/` ⇄ origin `https://localhost:8081`).


### PR DESCRIPTION
- TSDoc specifies the tag name as `@remarks` (not `@remark`).
- This aligns our comments with the spec and improves tooling support.
- No runtime behavior changes.
- Ref: https://tsdoc.org/pages/tags/remarks/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation to use the TSDoc-compliant `@remarks` tag for multiple properties across core and React Native packages.
  * Clarified docs for autoplay, controls, playsinline, rel, origin, useInlineHtml, and webViewUrl, with a spec reference link.
  * No API or runtime behavior changes.

* **Chores**
  * Published patch version bumps for react-native-youtube-bridge and @react-native-youtube-bridge/core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->