### PR TITLE
fix: preserve muted preference when replay starts after video end (#82)

### DIFF
--- a/.changeset/some-places-matter.md
+++ b/.changeset/some-places-matter.md
@@ -1,0 +1,12 @@
+---
+"react-native-youtube-bridge": patch
+"@react-native-youtube-bridge/react": patch
+"@react-native-youtube-bridge/core": patch
+"@react-native-youtube-bridge/web": patch
+---
+
+fix: preserve muted preference when replay starts after video end (#82)
+
+When a video is configured with muted=true, pressing the YouTube replay button after ENDED could resume playback with sound.  
+This patch preserves mute intent across replay by tracking the desired muted state and reapplying mute on ENDED->PLAYING transitions in both inline WebView and core controller paths.  
+It also synchronizes desired mute state when mute/unmute is explicitly toggled and updates iframe playerVars typing to include mute for consistency across web and native flows.  

--- a/packages/core/src/WebYoutubePlayerController.ts
+++ b/packages/core/src/WebYoutubePlayerController.ts
@@ -13,6 +13,7 @@ class WebYoutubePlayerController {
   private callbacks: PlayerEvents = {};
   private progressIntervalMs = 1000;
   private seekTimeout: NodeJS.Timeout | null = null;
+  private desiredMuted = false;
 
   static createInstance(): WebYoutubePlayerController {
     return new WebYoutubePlayerController();
@@ -81,6 +82,8 @@ class WebYoutubePlayerController {
       return;
     }
 
+    this.desiredMuted = Boolean(config.playerVars?.muted);
+
     if (this.player) {
       try {
         this.player.destroy();
@@ -97,6 +100,7 @@ class WebYoutubePlayerController {
         autoplay: config.playerVars?.autoplay ? 1 : 0,
         controls: config.playerVars?.controls ? 1 : 0,
         loop: config.playerVars?.loop ? 1 : 0,
+        mute: config.playerVars?.muted ? 1 : 0,
         start: config.playerVars?.startTime,
         end: config.playerVars?.endTime,
         playsinline: config.playerVars?.playsinline ? 1 : 0,
@@ -121,13 +125,15 @@ class WebYoutubePlayerController {
             volume: playerInfo.volume,
           });
 
+          this.applyDesiredMutedState();
           this.startProgressTracking();
         },
         onStateChange: (event) => {
           const state = event.data;
+          const mutedState = event.target?.playerInfo?.muted;
           this.callbacks.onStateChange?.(state);
 
-          this.handleStateChange(state);
+          this.handleStateChange(state, mutedState);
         },
         onError: (event) => {
           console.error('YouTube player error:', event.data);
@@ -157,7 +163,11 @@ class WebYoutubePlayerController {
     });
   }
 
-  private handleStateChange(state: number): void {
+  private handleStateChange(state: number, mutedState?: boolean): void {
+    if (state !== PlayerState.PLAYING && typeof mutedState === 'boolean') {
+      this.desiredMuted = mutedState;
+    }
+
     if (state === PlayerState.ENDED) {
       this.stopProgressTracking();
       this.sendProgress();
@@ -165,6 +175,7 @@ class WebYoutubePlayerController {
     }
 
     if (state === PlayerState.PLAYING) {
+      this.applyDesiredMutedState();
       this.startProgressTracking();
       return;
     }
@@ -271,10 +282,12 @@ class WebYoutubePlayerController {
   }
 
   mute(): void {
+    this.desiredMuted = true;
     this.player?.mute();
   }
 
   unMute(): void {
+    this.desiredMuted = false;
     this.player?.unMute();
   }
 
@@ -355,6 +368,18 @@ class WebYoutubePlayerController {
 
   updateCallbacks(newCallbacks: Partial<PlayerEvents>): void {
     this.callbacks = { ...this.callbacks, ...newCallbacks };
+  }
+
+  private applyDesiredMutedState(): void {
+    if (!this.desiredMuted) {
+      return;
+    }
+
+    try {
+      this.player?.mute();
+    } catch (error) {
+      console.warn('Failed to apply muted state:', error);
+    }
   }
 
   destroy(): void {

--- a/packages/core/src/types/iframe.ts
+++ b/packages/core/src/types/iframe.ts
@@ -44,6 +44,7 @@ export interface Options {
         list?: string | undefined;
         listType?: 'playlist' | 'search' | 'user_uploads' | undefined;
         loop?: 0 | 1 | undefined;
+        mute?: 0 | 1 | undefined;
         origin?: string | undefined;
         playlist?: string | undefined;
         playsinline?: 0 | 1 | undefined;

--- a/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
@@ -79,12 +79,50 @@ const useCreateLocalPlayerHtml = ({
             var player;
             var progressInterval;
             var isDestroyed = false;
+            var desiredMuted = ${muted ? 'true' : 'false'};
 
             function cleanup() {
               isDestroyed = true;
               if (progressInterval) {
                 clearInterval(progressInterval);
                 progressInterval = null;
+              }
+            }
+
+            function applyDesiredMutedState() {
+              if (!desiredMuted || !player || !player.mute) {
+                return;
+              }
+
+              try {
+                player.mute();
+              } catch (error) {
+                console.error('applyDesiredMutedState error:', error);
+              }
+            }
+
+            function syncDesiredMutedState(event) {
+              if (!event || !event.target) {
+                return;
+              }
+
+              try {
+                var mutedState;
+
+                if (typeof event.target.isMuted === 'function') {
+                  mutedState = event.target.isMuted();
+                } else if (
+                  event.target.playerInfo &&
+                  typeof event.target.playerInfo.muted === 'boolean'
+                ) {
+                  mutedState = event.target.playerInfo.muted;
+                }
+
+                if (typeof mutedState === 'boolean') {
+                  desiredMuted = mutedState;
+                }
+              } catch (error) {
+                console.error('syncDesiredMutedState error:', error);
               }
             }
 
@@ -122,6 +160,7 @@ const useCreateLocalPlayerHtml = ({
                     'onAutoplayBlocked': ${youtubeIframeScripts.onAutoplayBlocked}
                   }
                 });
+                applyDesiredMutedState();
               } catch (error) {
                 if (window.ReactNativeWebView) {
                   window.ReactNativeWebView.postMessage(JSON.stringify({
@@ -156,8 +195,14 @@ const useCreateLocalPlayerHtml = ({
               
               setVolume: (volume) => player && player.setVolume(volume),
               getVolume: () => player ? player.getVolume() : 0,
-              mute: () => player && player.mute(),
-              unMute: () => player && player.unMute(),
+              mute: () => {
+                desiredMuted = true;
+                return player && player.mute();
+              },
+              unMute: () => {
+                desiredMuted = false;
+                return player && player.unMute();
+              },
               isMuted: () => player ? player.isMuted() : false,
               
               getCurrentTime: () => player ? player.getCurrentTime() : 0,

--- a/packages/react-native-youtube-bridge/src/hooks/youtubeIframeScripts.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/youtubeIframeScripts.ts
@@ -114,6 +114,10 @@ const onPlayerStateChange = /* js */ `
         state: event.data
       }));
 
+      if (event.data !== YT.PlayerState.PLAYING) {
+        syncDesiredMutedState(event);
+      }
+
       if (event.data === YT.PlayerState.ENDED) {
         stopProgressTracking();
         sendProgress();
@@ -121,6 +125,7 @@ const onPlayerStateChange = /* js */ `
       }
 
       if (event.data === YT.PlayerState.PLAYING) {
+        applyDesiredMutedState();
         startProgressTracking();
         return;
       }


### PR DESCRIPTION
fix: #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed muted preference not being preserved when replaying a video after playback ends. Playback now resumes with the correct mute state across all implementations.
  * Mute state now properly synchronizes with explicit mute/unmute toggle actions.

* **Improvements**
  * Updated mute parameter configuration to ensure consistent behavior across web and native platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->