### PR TITLE
feat: add muteChange event with subscription-based muted state tracking

### DIFF
--- a/.changeset/flat-bats-greet.md
+++ b/.changeset/flat-bats-greet.md
@@ -1,0 +1,32 @@
+---
+"react-native-youtube-bridge": minor
+"@react-native-youtube-bridge/core": minor
+"@react-native-youtube-bridge/web": minor
+---
+
+feat: add muteChange event with subscription-based muted state tracking
+
+- Add `muteChange` event for real-time muted state updates.
+- Forward `muteChange` through core/web/webview/react-native bridge layers.
+- Enable muted-state tracking only while `muteChange` is subscribed (performance optimization).
+- Keep replay mute-preservation behavior intact.
+- Update the example app to use `useYouTubeEvent(player, 'muteChange', false)` for muted state.
+- Update README docs (EN/KO, root + package) to document `muteChange` usage and tracking behavior.
+
+```tsx
+import { YoutubeView, useYouTubeEvent, useYouTubePlayer } from 'react-native-youtube-bridge';
+
+function App() {
+  const player = useYouTubePlayer(videoIdOrUrl);
+
+  // 1. State-based event listening
+  const isMuted = useYouTubeEvent(player, 'muteChange', false);
+
+  // 2. Callback-based event listening
+  useYouTubeEvent(player, 'muteChange', (muted) => {
+    console.log('Player is muted:', muted);
+  });
+
+  return <YoutubeView player={player} />;
+}
+```

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -73,9 +73,12 @@ import { YoutubeView, useYouTubeEvent, useYouTubePlayer } from 'react-native-you
 function App() {
   const player = useYouTubePlayer(videoIdOrUrl);
 
+  // State-based event listening
   const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
+  const isMuted = useYouTubeEvent(player, 'muteChange', false);
   const progress = useYouTubeEvent(player, 'progress', progressInterval);
 
+  // Callback-based event listening
   useYouTubeEvent(player, 'ready', (playerInfo) => {
     console.log('Player is ready!');
     Alert.alert('Alert', 'YouTube player is ready!');
@@ -93,6 +96,9 @@ function App() {
   return <YoutubeView player={player} />;
 }
 ```
+
+`muteChange` 이벤트를 구독하면 YouTube 플레이어 기본 UI의 스피커 버튼 또는 `player.mute()` / `player.unMute()` 호출로 변경된 음소거 상태를 실시간으로 받을 수 있습니다.  
+성능 최적화를 위해 `muteChange`를 구독할 때만 muted tracking이 활성화됩니다.
 
 `useYouTubeEvent` hook은 callback으로 값을 전달받는 방식과 state로 값을 바로 사용할 수 있는 두 가지 방법을 제공합니다.
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ import { YoutubeView, useYouTubeEvent, useYouTubePlayer } from 'react-native-you
 function App() {
   const player = useYouTubePlayer(videoIdOrUrl);
 
+  // State-based event listening
   const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
+  const isMuted = useYouTubeEvent(player, 'muteChange', false);
   const progress = useYouTubeEvent(player, 'progress', progressInterval);
 
+  // Callback-based event listening
   useYouTubeEvent(player, 'ready', (playerInfo) => {
     console.log('Player is ready!');
     Alert.alert('Alert', 'YouTube player is ready!');
@@ -93,6 +96,9 @@ function App() {
   return <YoutubeView player={player} />;
 }
 ```
+
+`muteChange` emits real-time muted state updates from both the YouTube player's built-in mute control and `player.mute()` / `player.unMute()`.  
+For performance, muted tracking is enabled only while `muteChange` is subscribed.
 
 The `useYouTubeEvent` hook provides two ways to receive values: callback-based and state-based.
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,7 +27,6 @@ function App() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [availableRates, setAvailableRates] = useState<number[]>([1]);
   const [volume, setVolume] = useState(100);
-  const [isMuted, setIsMuted] = useState(false);
   const [videoId, setVideoId] = useState('AbZH7XWDW_k');
   const [progressInterval, setProgressInterval] = useState(1000);
   const { oEmbed, isLoading, error } = useYoutubeOEmbed(
@@ -42,6 +41,11 @@ function App() {
     muted: true,
   });
 
+  const isMuted = useYouTubeEvent(player, 'muteChange', false);
+  const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
+  const playbackQuality = useYouTubeEvent(player, 'playbackQualityChange');
+  const progress = useYouTubeEvent(player, 'progress', progressInterval);
+
   const changePlaybackRate = (rate: number) => {
     player.setPlaybackRate(rate);
   };
@@ -54,12 +58,10 @@ function App() {
   const toggleMute = useCallback(() => {
     if (isMuted) {
       player.unMute();
-      setIsMuted(false);
       return;
     }
 
     player.mute();
-    setIsMuted(true);
   }, [player, isMuted]);
 
   const onPlay = useCallback(() => {
@@ -100,10 +102,6 @@ function App() {
     );
   };
 
-  const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
-  const playbackQuality = useYouTubeEvent(player, 'playbackQualityChange');
-  const progress = useYouTubeEvent(player, 'progress', progressInterval);
-
   const currentTime = progress?.currentTime ?? 0;
   const duration = progress?.duration ?? 0;
   const loadedFraction = progress?.loadedFraction ?? 0;
@@ -122,10 +120,6 @@ function App() {
 
     if (playerInfo?.volume !== undefined) {
       setVolume(playerInfo.volume);
-    }
-
-    if (playerInfo?.muted !== undefined) {
-      setIsMuted(playerInfo.muted);
     }
   });
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
     muted: true,
   });
 
-  const isMuted = useYouTubeEvent(player, 'muteChange', false);
+  const isMuted = useYouTubeEvent(player, 'muteChange');
   const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
   const playbackQuality = useYouTubeEvent(player, 'playbackQualityChange');
   const progress = useYouTubeEvent(player, 'progress', progressInterval);

--- a/packages/core/src/WebYoutubePlayerController.ts
+++ b/packages/core/src/WebYoutubePlayerController.ts
@@ -127,7 +127,7 @@ class WebYoutubePlayerController {
             availableQualityLevels: playerInfo.availableQualityLevels,
             currentTime: playerInfo.currentTime,
             duration: playerInfo.duration,
-            muted: playerInfo.muted,
+            muted: readyMuted,
             playbackQuality: playerInfo.playbackQuality,
             playbackRate: playerInfo.playbackRate,
             playerState: playerInfo.playerState,

--- a/packages/core/src/WebYoutubePlayerController.ts
+++ b/packages/core/src/WebYoutubePlayerController.ts
@@ -296,13 +296,21 @@ class WebYoutubePlayerController {
 
   mute(): void {
     this.desiredMuted = true;
-    this.player?.mute();
+    if (!this.player) {
+      return;
+    }
+
+    this.player.mute();
     this.updateMutedState(true, true);
   }
 
   unMute(): void {
     this.desiredMuted = false;
-    this.player?.unMute();
+    if (!this.player) {
+      return;
+    }
+
+    this.player.unMute();
     this.updateMutedState(false, true);
   }
 

--- a/packages/core/src/WebYoutubePlayerController.ts
+++ b/packages/core/src/WebYoutubePlayerController.ts
@@ -7,12 +7,18 @@ type PlayerConfig = Omit<YoutubePlayerConfig, 'source'> & {
   videoId: string;
 };
 
+const MUTED_TRACKING_INTERVAL_MS = 250;
+
 class WebYoutubePlayerController {
   private player: YouTubePlayer | null = null;
   private progressInterval: NodeJS.Timeout | null = null;
   private callbacks: PlayerEvents = {};
   private progressIntervalMs = 1000;
   private seekTimeout: NodeJS.Timeout | null = null;
+  private mutedTrackingInterval: NodeJS.Timeout | null = null;
+  private isMutedSyncing = false;
+  private lastKnownMuted: boolean | null = null;
+  private mutedTrackingEnabled = false;
   private desiredMuted = false;
 
   static createInstance(): WebYoutubePlayerController {
@@ -83,6 +89,8 @@ class WebYoutubePlayerController {
     }
 
     this.desiredMuted = Boolean(config.playerVars?.muted);
+    this.lastKnownMuted = null;
+    this.stopMutedTracking();
 
     if (this.player) {
       try {
@@ -111,6 +119,8 @@ class WebYoutubePlayerController {
       events: {
         onReady: (event) => {
           const { playerInfo } = event.target;
+          const readyMuted =
+            typeof playerInfo.muted === 'boolean' ? playerInfo.muted : this.desiredMuted;
 
           this.callbacks.onReady?.({
             availablePlaybackRates: playerInfo.availablePlaybackRates,
@@ -125,15 +135,22 @@ class WebYoutubePlayerController {
             volume: playerInfo.volume,
           });
 
+          this.updateMutedState(readyMuted, true);
           this.applyDesiredMutedState();
           this.startProgressTracking();
+          this.startMutedTracking();
         },
         onStateChange: (event) => {
           const state = event.data;
           const mutedState = event.target?.playerInfo?.muted;
+
+          if (typeof mutedState === 'boolean') {
+            this.updateMutedState(mutedState, true);
+          }
+
           this.callbacks.onStateChange?.(state);
 
-          this.handleStateChange(state, mutedState);
+          this.handleStateChange(state);
         },
         onError: (event) => {
           console.error('YouTube player error:', event.data);
@@ -163,11 +180,7 @@ class WebYoutubePlayerController {
     });
   }
 
-  private handleStateChange(state: number, mutedState?: boolean): void {
-    if (state !== PlayerState.PLAYING && typeof mutedState === 'boolean') {
-      this.desiredMuted = mutedState;
-    }
-
+  private handleStateChange(state: number): void {
     if (state === PlayerState.ENDED) {
       this.stopProgressTracking();
       this.sendProgress();
@@ -284,11 +297,13 @@ class WebYoutubePlayerController {
   mute(): void {
     this.desiredMuted = true;
     this.player?.mute();
+    this.updateMutedState(true, true);
   }
 
   unMute(): void {
     this.desiredMuted = false;
     this.player?.unMute();
+    this.updateMutedState(false, true);
   }
 
   async isMuted(): Promise<boolean> {
@@ -370,6 +385,69 @@ class WebYoutubePlayerController {
     this.callbacks = { ...this.callbacks, ...newCallbacks };
   }
 
+  setMutedTrackingEnabled(enabled: boolean): void {
+    this.mutedTrackingEnabled = enabled;
+
+    if (enabled) {
+      this.lastKnownMuted = null;
+      this.startMutedTracking();
+      void this.syncMutedStateFromPlayer();
+      return;
+    }
+
+    this.stopMutedTracking();
+  }
+
+  private startMutedTracking(): void {
+    if (!this.mutedTrackingEnabled || !this.player) {
+      return;
+    }
+
+    this.stopMutedTracking();
+    this.mutedTrackingInterval = setInterval(() => {
+      void this.syncMutedStateFromPlayer();
+    }, MUTED_TRACKING_INTERVAL_MS);
+  }
+
+  private stopMutedTracking(): void {
+    if (this.mutedTrackingInterval) {
+      clearInterval(this.mutedTrackingInterval);
+      this.mutedTrackingInterval = null;
+    }
+    this.isMutedSyncing = false;
+  }
+
+  private async syncMutedStateFromPlayer(): Promise<void> {
+    if (this.isMutedSyncing || !this.player || !this.player.isMuted) {
+      return;
+    }
+
+    this.isMutedSyncing = true;
+
+    try {
+      const muted = await this.player.isMuted();
+      this.updateMutedState(Boolean(muted), true);
+    } catch {
+      // ignore polling errors while player is transitioning
+    } finally {
+      this.isMutedSyncing = false;
+    }
+  }
+
+  private updateMutedState(muted: boolean, emitEvent = true): void {
+    this.desiredMuted = muted;
+
+    if (this.lastKnownMuted === muted) {
+      return;
+    }
+
+    this.lastKnownMuted = muted;
+
+    if (emitEvent) {
+      this.callbacks.onMuteChange?.(muted);
+    }
+  }
+
   private applyDesiredMutedState(): void {
     if (!this.desiredMuted) {
       return;
@@ -377,6 +455,7 @@ class WebYoutubePlayerController {
 
     try {
       this.player?.mute();
+      this.updateMutedState(true, true);
     } catch (error) {
       console.warn('Failed to apply muted state:', error);
     }
@@ -384,6 +463,7 @@ class WebYoutubePlayerController {
 
   destroy(): void {
     this.stopProgressTracking();
+    this.stopMutedTracking();
 
     if (this.seekTimeout) {
       clearTimeout(this.seekTimeout);
@@ -398,6 +478,8 @@ class WebYoutubePlayerController {
       }
       this.player = null;
     }
+
+    this.lastKnownMuted = null;
   }
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -114,6 +114,11 @@ export type PlayerEvents = {
    * This event fires any time the browser blocks autoplay or scripted video playback features, collectively referred to as "autoplay".
    */
   onAutoplayBlocked?: () => void;
+  /**
+   * This event fires whenever the player's muted state changes.
+   * @param {boolean} muted - The current muted state.
+   */
+  onMuteChange?: (muted: boolean) => void;
 };
 
 /**
@@ -234,6 +239,7 @@ export type YoutubePlayerEvents = {
   playbackRateChange: number;
   playbackQualityChange: PlaybackQuality;
   autoplayBlocked: undefined;
+  muteChange: boolean;
 };
 
 export type EventCallback<Data = any> = (data: Data) => any;

--- a/packages/core/src/types/webview.ts
+++ b/packages/core/src/types/webview.ts
@@ -34,6 +34,11 @@ interface AutoplayBlockedMessageData {
   type: 'autoplayBlocked';
 }
 
+interface MuteChangeMessageData {
+  type: 'muteChange';
+  muted: boolean;
+}
+
 interface CommandResultMessageData {
   type: 'commandResult';
   id: string;
@@ -48,4 +53,5 @@ export type MessageData =
   | PlaybackRateChangeMessageData
   | PlaybackQualityChangeMessageData
   | AutoplayBlockedMessageData
+  | MuteChangeMessageData
   | CommandResultMessageData;

--- a/packages/react-native-youtube-bridge/README-ko_kr.md
+++ b/packages/react-native-youtube-bridge/README-ko_kr.md
@@ -73,9 +73,12 @@ import { YoutubeView, useYouTubeEvent, useYouTubePlayer } from 'react-native-you
 function App() {
   const player = useYouTubePlayer(videoIdOrUrl);
 
+  // State-based event listening
   const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
+  const isMuted = useYouTubeEvent(player, 'muteChange', false);
   const progress = useYouTubeEvent(player, 'progress', progressInterval);
 
+  // Callback-based event listening
   useYouTubeEvent(player, 'ready', (playerInfo) => {
     console.log('Player is ready!');
     Alert.alert('Alert', 'YouTube player is ready!');
@@ -93,6 +96,9 @@ function App() {
   return <YoutubeView player={player} />;
 }
 ```
+
+`muteChange` 이벤트를 구독하면 YouTube 플레이어 기본 UI의 스피커 버튼 또는 `player.mute()` / `player.unMute()` 호출로 변경된 음소거 상태를 실시간으로 받을 수 있습니다.  
+성능 최적화를 위해 `muteChange`를 구독할 때만 muted tracking이 활성화됩니다.
 
 `useYouTubeEvent` hook은 callback으로 값을 전달받는 방식과 state로 값을 바로 사용할 수 있는 두 가지 방법을 제공합니다.
 

--- a/packages/react-native-youtube-bridge/README.md
+++ b/packages/react-native-youtube-bridge/README.md
@@ -73,9 +73,12 @@ import { YoutubeView, useYouTubeEvent, useYouTubePlayer } from 'react-native-you
 function App() {
   const player = useYouTubePlayer(videoIdOrUrl);
 
+  // State-based event listening
   const playbackRate = useYouTubeEvent(player, 'playbackRateChange', 1);
+  const isMuted = useYouTubeEvent(player, 'muteChange', false);
   const progress = useYouTubeEvent(player, 'progress', progressInterval);
 
+  // Callback-based event listening
   useYouTubeEvent(player, 'ready', (playerInfo) => {
     console.log('Player is ready!');
     Alert.alert('Alert', 'YouTube player is ready!');
@@ -93,6 +96,9 @@ function App() {
   return <YoutubeView player={player} />;
 }
 ```
+
+`muteChange` emits real-time muted state updates from both the YouTube player's built-in mute control and `player.mute()` / `player.unMute()`.  
+For performance, muted tracking is enabled only while `muteChange` is subscribed.
 
 The `useYouTubeEvent` hook provides two ways to receive values: callback-based and state-based.
 

--- a/packages/react-native-youtube-bridge/src/YoutubeView.tsx
+++ b/packages/react-native-youtube-bridge/src/YoutubeView.tsx
@@ -115,6 +115,11 @@ function YoutubeView({
           player.emit(data.type, undefined);
           return;
         }
+
+        if (data.type === 'muteChange') {
+          player.emit(data.type, data.muted);
+          return;
+        }
       } catch (error) {
         if (__DEV__) {
           console.error('Error parsing WebView message:', error, event?.nativeEvent?.data);

--- a/packages/react-native-youtube-bridge/src/YoutubeView.web.tsx
+++ b/packages/react-native-youtube-bridge/src/YoutubeView.web.tsx
@@ -62,6 +62,9 @@ function YoutubeView({ player, height, width, style, iframeStyle }: YoutubeViewP
       onAutoplayBlocked: () => {
         player.emit('autoplayBlocked', undefined);
       },
+      onMuteChange: (muted) => {
+        player.emit('muteChange', muted);
+      },
       onProgress: (progress) => {
         player.emit('progress', progress);
       },

--- a/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
@@ -78,14 +78,45 @@ const useCreateLocalPlayerHtml = ({
 
             var player;
             var progressInterval;
+            var mutedTrackingInterval;
             var isDestroyed = false;
+            var isMutedTrackingEnabled = false;
             var desiredMuted = ${muted ? 'true' : 'false'};
+            var lastKnownMuted = null;
 
             function cleanup() {
               isDestroyed = true;
               if (progressInterval) {
                 clearInterval(progressInterval);
                 progressInterval = null;
+              }
+              stopMutedTracking();
+            }
+
+            function emitMutedChange(muted) {
+              if (window.ReactNativeWebView) {
+                window.ReactNativeWebView.postMessage(JSON.stringify({
+                  type: 'muteChange',
+                  muted: muted
+                }));
+              }
+            }
+
+            function updateMutedState(mutedState, shouldEmit) {
+              if (typeof mutedState !== 'boolean') {
+                return;
+              }
+
+              desiredMuted = mutedState;
+
+              if (lastKnownMuted === mutedState) {
+                return;
+              }
+
+              lastKnownMuted = mutedState;
+
+              if (shouldEmit !== false) {
+                emitMutedChange(mutedState);
               }
             }
 
@@ -96,12 +127,13 @@ const useCreateLocalPlayerHtml = ({
 
               try {
                 player.mute();
+                updateMutedState(true, isMutedTrackingEnabled);
               } catch (error) {
                 console.error('applyDesiredMutedState error:', error);
               }
             }
 
-            function syncDesiredMutedState(event) {
+            function syncDesiredMutedState(event, shouldEmit) {
               if (!event || !event.target) {
                 return;
               }
@@ -118,11 +150,43 @@ const useCreateLocalPlayerHtml = ({
                   mutedState = event.target.playerInfo.muted;
                 }
 
-                if (typeof mutedState === 'boolean') {
-                  desiredMuted = mutedState;
-                }
+                updateMutedState(mutedState, shouldEmit);
               } catch (error) {
                 console.error('syncDesiredMutedState error:', error);
+              }
+            }
+
+            function syncMutedStateFromPlayer(shouldEmit) {
+              if (!player || typeof player.isMuted !== 'function') {
+                return;
+              }
+
+              try {
+                updateMutedState(player.isMuted(), shouldEmit);
+              } catch (error) {
+                console.error('syncMutedStateFromPlayer error:', error);
+              }
+            }
+
+            function startMutedTracking() {
+              if (!isMutedTrackingEnabled) {
+                return;
+              }
+
+              stopMutedTracking();
+              mutedTrackingInterval = setInterval(function() {
+                if (isDestroyed) {
+                  stopMutedTracking();
+                  return;
+                }
+                syncMutedStateFromPlayer(true);
+              }, 250);
+            }
+
+            function stopMutedTracking() {
+              if (mutedTrackingInterval) {
+                clearInterval(mutedTrackingInterval);
+                mutedTrackingInterval = null;
               }
             }
 
@@ -161,6 +225,7 @@ const useCreateLocalPlayerHtml = ({
                   }
                 });
                 applyDesiredMutedState();
+                startMutedTracking();
               } catch (error) {
                 if (window.ReactNativeWebView) {
                   window.ReactNativeWebView.postMessage(JSON.stringify({
@@ -196,11 +261,11 @@ const useCreateLocalPlayerHtml = ({
               setVolume: (volume) => player && player.setVolume(volume),
               getVolume: () => player ? player.getVolume() : 0,
               mute: () => {
-                desiredMuted = true;
+                updateMutedState(true, isMutedTrackingEnabled);
                 return player && player.mute();
               },
               unMute: () => {
-                desiredMuted = false;
+                updateMutedState(false, isMutedTrackingEnabled);
                 return player && player.unMute();
               },
               isMuted: () => player ? player.isMuted() : false,
@@ -248,6 +313,17 @@ const useCreateLocalPlayerHtml = ({
                 if (interval && player && player.getPlayerState() === YT.PlayerState.PLAYING) {
                   startProgressTracking();
                 }
+              },
+              setMutedTrackingEnabled: (enabled) => {
+                isMutedTrackingEnabled = enabled === true;
+                if (isMutedTrackingEnabled) {
+                  lastKnownMuted = null;
+                  syncMutedStateFromPlayer(true);
+                  startMutedTracking();
+                  return;
+                }
+
+                stopMutedTracking();
               },
               cleanup: cleanup,
             };

--- a/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/useCreateLocalPlayerHtml.ts
@@ -261,12 +261,22 @@ const useCreateLocalPlayerHtml = ({
               setVolume: (volume) => player && player.setVolume(volume),
               getVolume: () => player ? player.getVolume() : 0,
               mute: () => {
+                desiredMuted = true;
+                if (!player) {
+                  return;
+                }
+
+                player.mute();
                 updateMutedState(true, isMutedTrackingEnabled);
-                return player && player.mute();
               },
               unMute: () => {
+                desiredMuted = false;
+                if (!player) {
+                  return;
+                }
+
+                player.unMute();
                 updateMutedState(false, isMutedTrackingEnabled);
-                return player && player.unMute();
               },
               isMuted: () => player ? player.isMuted() : false,
               

--- a/packages/react-native-youtube-bridge/src/hooks/useYouTubeEvent.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/useYouTubeEvent.ts
@@ -2,7 +2,10 @@ import type { EventCallback, YoutubePlayerEvents } from '@react-native-youtube-b
 import { useEffect, useRef, useState } from 'react';
 
 import type YoutubePlayer from '../modules/YoutubePlayer';
-import { INTERNAL_SET_PROGRESS_INTERVAL } from '../modules/YoutubePlayer';
+import {
+  INTERNAL_SET_MUTE_TRACKING,
+  INTERNAL_SET_PROGRESS_INTERVAL,
+} from '../modules/YoutubePlayer';
 
 const DEFAULT_PROGRESS_INTERVAL = 1000;
 
@@ -122,6 +125,18 @@ function useYouTubeEvent<T extends keyof YoutubePlayerEvents>(
       player[INTERNAL_SET_PROGRESS_INTERVAL](throttleMs);
     }
   }, [throttleMs, player]);
+
+  useEffect(() => {
+    if (!player || eventType !== 'muteChange') {
+      return;
+    }
+
+    player[INTERNAL_SET_MUTE_TRACKING](true);
+
+    return () => {
+      player[INTERNAL_SET_MUTE_TRACKING](false);
+    };
+  }, [player, eventType]);
 
   useEffect(() => {
     if (!player) {

--- a/packages/react-native-youtube-bridge/src/hooks/youtubeIframeScripts.ts
+++ b/packages/react-native-youtube-bridge/src/hooks/youtubeIframeScripts.ts
@@ -80,6 +80,7 @@ const onPlayerReady = /* js */ `
     const playerInfo = event.target.playerInfo;
     
     try {
+      syncDesiredMutedState(event, isMutedTrackingEnabled);
       window.ReactNativeWebView.postMessage(JSON.stringify({
         type: 'ready',
         playerInfo: {
@@ -115,7 +116,7 @@ const onPlayerStateChange = /* js */ `
       }));
 
       if (event.data !== YT.PlayerState.PLAYING) {
-        syncDesiredMutedState(event);
+        syncDesiredMutedState(event, isMutedTrackingEnabled);
       }
 
       if (event.data === YT.PlayerState.ENDED) {

--- a/packages/react-native-youtube-bridge/src/modules/WebviewYoutubePlayerController.ts
+++ b/packages/react-native-youtube-bridge/src/modules/WebviewYoutubePlayerController.ts
@@ -112,6 +112,10 @@ class WebviewYoutubePlayerController {
     await this.executeCommand('updateProgressInterval', [interval]);
   }
 
+  async setMutedTrackingEnabled(enabled: boolean): Promise<void> {
+    await this.executeCommand('setMutedTrackingEnabled', [enabled]);
+  }
+
   private executeCommand(
     command: string,
     args: (string | number | boolean | undefined)[] = [],

--- a/packages/react-native-youtube-bridge/src/modules/YoutubePlayer.ts
+++ b/packages/react-native-youtube-bridge/src/modules/YoutubePlayer.ts
@@ -10,6 +10,7 @@ import type WebviewYoutubePlayerController from './WebviewYoutubePlayerControlle
 export const INTERNAL_SET_CONTROLLER_INSTANCE = Symbol('setControllerInstance');
 export const INTERNAL_UPDATE_PROGRESS_INTERVAL = Symbol('updateProgressInterval');
 export const INTERNAL_SET_PROGRESS_INTERVAL = Symbol('setProgressInterval');
+export const INTERNAL_SET_MUTE_TRACKING = Symbol('setMuteTracking');
 
 type YoutubeEventType = keyof YoutubePlayerEvents;
 
@@ -19,6 +20,7 @@ class YoutubePlayer {
   private controller: WebviewYoutubePlayerController | WebYoutubePlayerController | null = null;
 
   private progressInterval: number | null = null;
+  private muteChangeSubscriptionCount = 0;
 
   private videoId: string | null | undefined;
   private options: YoutubePlayerVars;
@@ -50,6 +52,7 @@ class YoutubePlayer {
     controller: WebviewYoutubePlayerController | WebYoutubePlayerController | null,
   ): void {
     this.controller = controller;
+    this.controller?.setMutedTrackingEnabled(this.muteChangeSubscriptionCount > 0);
   }
 
   [INTERNAL_SET_PROGRESS_INTERVAL](interval: number): void {
@@ -63,6 +66,18 @@ class YoutubePlayer {
     if (this.progressInterval) {
       this.controller?.updateProgressInterval(this.progressInterval);
     }
+  }
+
+  [INTERNAL_SET_MUTE_TRACKING](enabled: boolean): void {
+    if (enabled) {
+      this.muteChangeSubscriptionCount += 1;
+    }
+
+    if (!enabled) {
+      this.muteChangeSubscriptionCount = Math.max(0, this.muteChangeSubscriptionCount - 1);
+    }
+
+    this.controller?.setMutedTrackingEnabled(this.muteChangeSubscriptionCount > 0);
   }
 
   subscribe<T extends YoutubeEventType>(
@@ -338,6 +353,7 @@ class YoutubePlayer {
     this.controller?.destroy();
     this.controller = null;
     this.progressInterval = null;
+    this.muteChangeSubscriptionCount = 0;
   }
 }
 

--- a/packages/react-native-youtube-bridge/src/types/message.ts
+++ b/packages/react-native-youtube-bridge/src/types/message.ts
@@ -6,6 +6,7 @@ export type MessageType =
   | 'playbackRateChange'
   | 'playbackQualityChange'
   | 'autoplayBlocked'
+  | 'muteChange'
   | 'commandResult';
 
 export type CommandType =
@@ -30,5 +31,6 @@ export type CommandType =
   | 'loadVideoById'
   | 'cueVideoById'
   | 'setSize'
+  | 'setMutedTrackingEnabled'
   | 'cleanup'
   | 'updateProgressInterval';

--- a/packages/web/src/YoutubePlayer.tsx
+++ b/packages/web/src/YoutubePlayer.tsx
@@ -85,6 +85,12 @@ function YoutubePlayer() {
           type: 'autoplayBlocked',
         });
       },
+      onMuteChange: (muted) => {
+        sendMessage({
+          type: 'muteChange',
+          muted,
+        });
+      },
       onProgress: (progress) => {
         sendMessage({
           type: 'progress',

--- a/packages/web/src/types/message.ts
+++ b/packages/web/src/types/message.ts
@@ -1,6 +1,7 @@
 import type { PlayerControls } from '@react-native-youtube-bridge/core';
 
 interface ReceivePlayerControls extends PlayerControls {
+  setMutedTrackingEnabled: (enabled: boolean) => void;
   cleanup: () => void;
   updateProgressInterval: (interval: number) => void;
 }


### PR DESCRIPTION
- Add `muteChange` event for real-time muted state updates.
- Forward `muteChange` through core/web/webview/react-native bridge layers.
- Enable muted-state tracking only while `muteChange` is subscribed (performance optimization).
- Keep replay mute-preservation behavior intact.
- Update the example app to use `useYouTubeEvent(player, 'muteChange', false)` for muted state.
- Update README docs (EN/KO, root + package) to document `muteChange` usage and tracking behavior.

```tsx
import { YoutubeView, useYouTubeEvent, useYouTubePlayer } from 'react-native-youtube-bridge';

function App() {
  const player = useYouTubePlayer(videoIdOrUrl);

  // 1. State-based event listening
  const isMuted = useYouTubeEvent(player, 'muteChange', false);

  // 2. Callback-based event listening
  useYouTubeEvent(player, 'muteChange', (muted) => {
    console.log('Player is muted:', muted);
  });

  return <YoutubeView player={player} />;
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `muteChange` event to receive real-time muted state updates (UI button and programmatic mute/unMute).
  * `useYouTubeEvent` supports both state-based (e.g., isMuted via useYouTubeEvent(player, 'muteChange', false)) and callback-based subscriptions.

* **Behavior**
  * Muted-state tracking is enabled only while `muteChange` is subscribed to (performance optimization).

* **Documentation**
  * Examples and READMEs updated to show `muteChange` usage and migration to event-driven mute state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->