### PR TITLE
fix: keep package exports aligned with tsdown

### DIFF
--- a/.changeset/fix-tsdown-package-entrypoints.md
+++ b/.changeset/fix-tsdown-package-entrypoints.md
@@ -1,0 +1,8 @@
+---
+"@react-native-youtube-bridge/core": patch
+"@react-native-youtube-bridge/react": patch
+"@react-native-youtube-bridge/web": patch
+"react-native-youtube-bridge": patch
+---
+
+Fix package entry metadata to match tsdown's `.cjs`, `.mjs`, and `.d.mts` outputs so Expo Snack and CommonJS resolvers can load the internal packages.

--- a/.changeset/fix-tsdown-package-entrypoints.md
+++ b/.changeset/fix-tsdown-package-entrypoints.md
@@ -5,4 +5,4 @@
 "react-native-youtube-bridge": patch
 ---
 
-Fix package entry metadata to match tsdown's `.cjs`, `.mjs`, and `.d.mts` outputs so Expo Snack and CommonJS resolvers can load the internal packages.
+Fix package entry metadata to match tsdown's `.cjs`, `.mjs`, `.d.cts`, and `.d.mts` outputs so Expo Snack and TypeScript CJS/ESM resolvers can load the internal packages.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,15 +3,15 @@ pre-commit:
   commands:
     lint:
       glob: '**/*.{js,ts,jsx,tsx}'
-      run: pnpm oxlint {staged_files}
+      run: corepack pnpm oxlint {staged_files}
     format:
       glob: '**/*.{js,ts,jsx,tsx}'
-      run: pnpm oxfmt {staged_files}
+      run: corepack pnpm oxfmt {staged_files}
     types:
       glob: '**/*.{js,ts,jsx,tsx}'
-      run: pnpm run typecheck
+      run: corepack pnpm run typecheck
 commit-msg:
   parallel: true
   commands:
     commitlint:
-      run: pnpm commitlint --edit
+      run: corepack pnpm commitlint --edit

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,10 +32,14 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.mjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,15 +26,18 @@
     "dist",
     "package.json"
   ],
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,4 +1,16 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, type ExportsOptions } from 'tsdown';
+
+const exportsConfig: ExportsOptions = {
+  customExports(exports) {
+    exports['.'] = {
+      types: './dist/index.d.mts',
+      ...exports['.'],
+      default: './dist/index.mjs',
+    };
+
+    return exports;
+  },
+};
 
 export default defineConfig([
   {
@@ -6,5 +18,6 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     outDir: 'dist',
     dts: true,
+    exports: exportsConfig,
   },
 ]);

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -3,9 +3,14 @@ import { defineConfig, type ExportsOptions } from 'tsdown';
 const exportsConfig: ExportsOptions = {
   customExports(exports) {
     exports['.'] = {
-      types: './dist/index.d.mts',
-      ...exports['.'],
-      default: './dist/index.mjs',
+      import: {
+        types: './dist/index.d.mts',
+        default: './dist/index.mjs',
+      },
+      require: {
+        types: './dist/index.d.cts',
+        default: './dist/index.cjs',
+      },
     };
 
     return exports;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,10 +32,14 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.mjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,15 +26,18 @@
     "dist",
     "package.json"
   ],
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -1,4 +1,16 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, type ExportsOptions } from 'tsdown';
+
+const exportsConfig: ExportsOptions = {
+  customExports(exports) {
+    exports['.'] = {
+      types: './dist/index.d.mts',
+      ...exports['.'],
+      default: './dist/index.mjs',
+    };
+
+    return exports;
+  },
+};
 
 export default defineConfig([
   {
@@ -6,5 +18,6 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     outDir: 'dist',
     dts: true,
+    exports: exportsConfig,
   },
 ]);

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -3,9 +3,14 @@ import { defineConfig, type ExportsOptions } from 'tsdown';
 const exportsConfig: ExportsOptions = {
   customExports(exports) {
     exports['.'] = {
-      types: './dist/index.d.mts',
-      ...exports['.'],
-      default: './dist/index.mjs',
+      import: {
+        types: './dist/index.d.mts',
+        default: './dist/index.mjs',
+      },
+      require: {
+        types: './dist/index.d.cts',
+        default: './dist/index.cjs',
+      },
     };
 
     return exports;


### PR DESCRIPTION
Expo Snack exposes a resolver failure from missing dist/index.js metadata.

Tsdown emits .cjs/.mjs files, so package exports need to follow that output.

Generate exports from tsdown config and run lefthook via Corepack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package entry resolution so the library works more reliably in Expo Snack and CommonJS environments.
  * Fixed published package metadata to better support both ESM and CommonJS consumers.

* **Chores**
  * Updated release metadata and local tooling to use consistent package-manager commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->